### PR TITLE
🚑 Fix: body 태그 내부는 최상단 기준으로 정렬됩니다.

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -24,7 +24,7 @@ body {
 	margin: 0;
 	padding: 0;
 	display: flex;
-	place-items: center;
+	place-items: start;
 	min-width: 320px;
 	min-height: 100vh;
 }


### PR DESCRIPTION
## 이슈 번호
#21

## 작업 상세 내용
- body 정렬을 가운데 에서 최상단으로 변경했습니다.

## 체크 리스트
- [x] main 브랜치 pull 받기
- [x] reviewer 설정 확인
- [x] Assignees 설정 확인

🔴 **이건 반드시 확인해 주세요!**

### 중간 정렬일 경우, body 태그 내부 컴포넌트 heigth 에 따라 화면에 다르게 보입니다.

<img width="1470" alt="스크린샷 2023-11-19 오전 1 22 47" src="https://github.com/2023-frontend1/Paprika-Market/assets/50646145/a77716af-0254-482a-92cb-24297e4f3cdf">
<img width="1470" alt="스크린샷 2023-11-19 오전 1 22 25" src="https://github.com/2023-frontend1/Paprika-Market/assets/50646145/cf056270-2120-4f31-9434-b1bb33dc8cf1">


<br/>
<br/>

### 'start' 로 정렬하면, 컴포넌트가 가장 상단에 붙혀지기 때문에 UI 를 일관되게 만들 수 있습니다.

<img width="1470" alt="스크린샷 2023-11-19 오전 1 25 21" src="https://github.com/2023-frontend1/Paprika-Market/assets/50646145/ae2e2fd2-bf70-4099-b905-6f2a6e2ae7bb">
<img width="1470" alt="스크린샷 2023-11-19 오전 1 24 59" src="https://github.com/2023-frontend1/Paprika-Market/assets/50646145/dc68defe-6e4c-4bff-8d7b-232142722cf9">
